### PR TITLE
Little endian wkb

### DIFF
--- a/lib/active_record/connection_adapters/mysql2spatial_adapter/arel_tosql.rb
+++ b/lib/active_record/connection_adapters/mysql2spatial_adapter/arel_tosql.rb
@@ -41,9 +41,9 @@ module Arel
       end
 
       FUNC_MAP = {
-        'st_wkttosql' => 'GeomFromText',
-        'st_wkbtosql' => 'GeomFromWKB',
-        'st_length' => 'GLength',
+        'st_wkttosql' => 'ST_GeomFromText',
+        'st_wkbtosql' => 'ST_GeomFromWKB',
+        'st_length' => 'ST_Length',
       }
 
       include ::RGeo::ActiveRecord::SpatialToSql

--- a/lib/active_record/connection_adapters/mysql2spatial_adapter/main_adapter.rb
+++ b/lib/active_record/connection_adapters/mysql2spatial_adapter/main_adapter.rb
@@ -65,7 +65,7 @@ module ActiveRecord
 
         def quote(value_, column_=nil)
           if ::RGeo::Feature::Geometry.check_type(value_)
-            "GeomFromWKB(0x#{::RGeo::WKRep::WKBGenerator.new(hex_format: true).generate(value_)},#{value_.srid})"
+            "ST_GeomFromWKB(0x#{::RGeo::WKRep::WKBGenerator.new(hex_format: true).generate(value_)},#{value_.srid})"
           else
             super
           end

--- a/lib/active_record/connection_adapters/mysql2spatial_adapter/main_adapter.rb
+++ b/lib/active_record/connection_adapters/mysql2spatial_adapter/main_adapter.rb
@@ -63,9 +63,12 @@ module ActiveRecord
           NATIVE_DATABASE_TYPES
         end
 
+        # By default, RGeo::WKRep::WKBGenerator generates WKB in big-endian format,
+        # But MySQL running on x86 uses little-endian,
+        # Force RGeo::WKRep::WKBGenerator to generate WKB in little endian format.
         def quote(value_, column_=nil)
           if ::RGeo::Feature::Geometry.check_type(value_)
-            "ST_GeomFromWKB(0x#{::RGeo::WKRep::WKBGenerator.new(hex_format: true).generate(value_)},#{value_.srid})"
+            "ST_GeomFromWKB(0x#{::RGeo::WKRep::WKBGenerator.new(hex_format: true, little_endian: true).generate(value_)},#{value_.srid})"
           else
             super
           end

--- a/lib/active_record/type/spatial.rb
+++ b/lib/active_record/type/spatial.rb
@@ -19,6 +19,10 @@ module ActiveRecord
         @geometric_type = geometric_type
       end
 
+      def changed?(old_value, new_value, _new_value_before_type_cast)
+        old_value.to_s != new_value.to_s
+      end
+
       private
 
       def cast_value(value)

--- a/lib/active_record/type/spatial.rb
+++ b/lib/active_record/type/spatial.rb
@@ -20,7 +20,7 @@ module ActiveRecord
       end
 
       def changed?(old_value, new_value, _new_value_before_type_cast)
-        old_value.to_s != new_value.to_s
+        old_value.to_s != new_value.to_s || old_value.srid != new_value.srid
       end
 
       private


### PR DESCRIPTION
## Changes
- Prefix all MySQL geometry functions' names with `ST_`
- Force `ST_GeomFromWKB` to generate bytes in little_endian format.
- Spatial data should be updated if there're changes in SRID or shape. 